### PR TITLE
[Feat, Fix] : 포트폴리오 수정, 삭제 API 추가 및 프론트 요청에 따라 반환 형식 변경

### DIFF
--- a/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/controller/PortfolioController.java
+++ b/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/controller/PortfolioController.java
@@ -3,6 +3,7 @@ package CamNecT.CamNecT_Server.domain.portfolio.controller;
 import CamNecT.CamNecT_Server.domain.portfolio.dto.request.PortfolioRequest;
 import CamNecT.CamNecT_Server.domain.portfolio.dto.response.PortfolioDetailResponse;
 import CamNecT.CamNecT_Server.domain.portfolio.dto.response.PortfolioPreviewResponse;
+import CamNecT.CamNecT_Server.domain.portfolio.dto.response.PortfolioResponse;
 import CamNecT.CamNecT_Server.domain.portfolio.service.PortfolioService;
 import CamNecT.CamNecT_Server.global.common.auth.UserId;
 import CamNecT.CamNecT_Server.global.common.response.ApiResponse;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/portfolio")
+@RequestMapping("/api/portfolio/{portfolioUserId}")
 @RequiredArgsConstructor
 public class PortfolioController {
 
@@ -25,22 +26,49 @@ public class PortfolioController {
     private final PresignEngine presignEngine;
 
     @GetMapping
-    public List<PortfolioPreviewResponse> portfolioPreview (@UserId Long userId){
-        return portfolioService.portfolioPreview(userId);
+    public ApiResponse<PortfolioResponse<List<PortfolioPreviewResponse>>> portfolioPreview (@UserId Long userId, @PathVariable Long portfolioUserId){
+        return ApiResponse.success(portfolioService.portfolioPreview(userId, portfolioUserId));
     }
 
-    @GetMapping("{portfolioId}")
-    public PortfolioDetailResponse portfolioDetail (@UserId Long userId, @PathVariable Long portfolioId) {
-        return portfolioService.portfolioDetail(userId, portfolioId);
+    @GetMapping("/{portfolioId}")
+    public ApiResponse<PortfolioResponse<PortfolioDetailResponse>> portfolioDetail (@UserId Long userId, @PathVariable Long portfolioUserId,@PathVariable Long portfolioId) {
+        return ApiResponse.success(portfolioService.portfolioDetail(userId, portfolioUserId,portfolioId));
     }
 
     @PostMapping
-    public PortfolioPreviewResponse createPortfolio (@UserId Long userId, @RequestBody @Valid PortfolioRequest portfolioRequest){
+    public ApiResponse<PortfolioPreviewResponse> createPortfolio (@UserId Long userId, @PathVariable Long portfolioUserId, @RequestBody @Valid PortfolioRequest portfolioRequest){
 
-        return portfolioService.create(userId, portfolioRequest);
+        return ApiResponse.success(portfolioService.create(userId, portfolioUserId, portfolioRequest));
     }
 
-    //todo : 수정 삭제 로직 구현
+    @PatchMapping("/{portfolioId}")
+    public ApiResponse<PortfolioPreviewResponse> updatePortfolio (@UserId Long userId, @PathVariable Long portfolioId, @RequestBody @Valid PortfolioRequest portfolioRequest){
+        return ApiResponse.success(portfolioService.update(userId, portfolioId,portfolioRequest));
+    }
+
+    @DeleteMapping("/{portfolioId}")
+    public ApiResponse<String> deletePortfolio(@UserId Long userId, @PathVariable Long portfolioId){
+        portfolioService.delete(userId, portfolioId);
+        return ApiResponse.success("포트폴리오가 삭제되었습니다.");
+    }
+
+    // 공개 여부 설정
+    @PatchMapping("/{portfolioId}/public")
+    public ApiResponse<Boolean> togglePublic(
+            @UserId Long userId,
+            @PathVariable Long portfolioId
+    ) {
+        return ApiResponse.success(portfolioService.togglePublic(userId, portfolioId));
+    }
+
+    // 즐겨찾기 설정
+    @PatchMapping("/{portfolioId}/favorite")
+    public ApiResponse<Boolean> toggleFavorite(
+            @UserId Long userId,
+            @PathVariable Long portfolioId
+    ) {
+        return ApiResponse.success(portfolioService.toggleFavorite(userId, portfolioId));
+    }
 
 
     @PostMapping("/uploads/presign/thumbnail")

--- a/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/dto/PortfolioProjectDto.java
+++ b/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/dto/PortfolioProjectDto.java
@@ -1,0 +1,46 @@
+package CamNecT.CamNecT_Server.domain.portfolio.dto;
+
+
+import CamNecT.CamNecT_Server.domain.portfolio.model.PortfolioProject;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record PortfolioProjectDto(
+        Long portfolioId,
+        Long userId,
+        String title,
+        String thumbnailUrl, // S3 Presigned URL이 담길 곳
+        LocalDate startDate,
+        LocalDate endDate,
+        String description,
+        boolean isPublic,
+        boolean isFavorite,
+        List<String> projectField,
+        List<String> assignedRole,
+        List<String> techStack,
+        String review,
+        LocalDate createdAt,
+        LocalDate updatedAt
+) {
+    // 엔티티를 DTO로 변환하는 정적 팩토리 메서드 (서비스 로직 깔끔화)
+    public static PortfolioProjectDto from(PortfolioProject p, String fullThumbnailUrl) {
+        return new PortfolioProjectDto(
+                p.getPortfolioId(),
+                p.getUserId(),
+                p.getTitle(),
+                fullThumbnailUrl,
+                p.getStartDate(),
+                p.getEndDate(),
+                p.getDescription(),
+                p.isPublic(),
+                p.isFavorite(),
+                p.getProjectField(),
+                p.getAssignedRole(),
+                p.getTechStack(),
+                p.getReview(),
+                p.getCreatedAt(),
+                p.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/dto/response/PortfolioDetailResponse.java
+++ b/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/dto/response/PortfolioDetailResponse.java
@@ -1,11 +1,11 @@
 package CamNecT.CamNecT_Server.domain.portfolio.dto.response;
 
-import CamNecT.CamNecT_Server.domain.portfolio.model.PortfolioProject;
+import CamNecT.CamNecT_Server.domain.portfolio.dto.PortfolioProjectDto;
 
 import java.util.List;
 
 public record PortfolioDetailResponse(
     Boolean isMine,
-    PortfolioProject portfolio,
+    PortfolioProjectDto portfolio,
     List<PortfolioAssetView> portfolioAssets
 ) {}

--- a/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/dto/response/PortfolioPreviewResponse.java
+++ b/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/dto/response/PortfolioPreviewResponse.java
@@ -5,13 +5,17 @@ import CamNecT.CamNecT_Server.domain.portfolio.model.PortfolioProject;
 public record PortfolioPreviewResponse(
         Long portfolioId,
         String title,
-        String thumbnailUrl
+        String thumbnailUrl,
+        boolean isPublic,
+        boolean isFavorite
 ) {
     public static PortfolioPreviewResponse of(PortfolioProject project) {
         return new PortfolioPreviewResponse(
                 project.getPortfolioId(),
                 project.getTitle(),
-                project.getThumbnailUrl()
+                project.getThumbnailUrl(),
+                project.isPublic(),
+                project.isFavorite()
         );
     }
 }

--- a/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/dto/response/PortfolioResponse.java
+++ b/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/dto/response/PortfolioResponse.java
@@ -1,0 +1,10 @@
+package CamNecT.CamNecT_Server.domain.portfolio.dto.response;
+
+public record PortfolioResponse<T>(
+        boolean isMine,
+        T data
+) {
+    public static <T> PortfolioResponse<T> of(boolean isMine, T data) {
+        return new PortfolioResponse<>(isMine, data);
+    }
+}

--- a/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/repository/PortfolioRepository.java
@@ -12,9 +12,10 @@ import java.util.List;
 @Repository
 public interface PortfolioRepository extends JpaRepository<PortfolioProject, Long> {
 
-    @Query("SELECT new CamNecT.CamNecT_Server.domain.portfolio.dto.response.PortfolioPreviewResponse(p.portfolioId, p.title, p.thumbnailUrl) " +
+    @Query("SELECT new CamNecT.CamNecT_Server.domain.portfolio.dto.response.PortfolioPreviewResponse(p.portfolioId, p.title, p.thumbnailUrl, p.isPublic, p.isFavorite) " +
             "FROM PortfolioProject p " +
-            "WHERE p.userId = :userId")
+            "WHERE p.userId = :userId " +
+            "ORDER BY p.createdAt DESC")
     List<PortfolioPreviewResponse> findPreviewsByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/CamNecT/CamNecT_Server/domain/portfolio/service/PortfolioService.java
@@ -1,9 +1,11 @@
 package CamNecT.CamNecT_Server.domain.portfolio.service;
 
+import CamNecT.CamNecT_Server.domain.portfolio.dto.PortfolioProjectDto;
 import CamNecT.CamNecT_Server.domain.portfolio.dto.request.PortfolioRequest;
 import CamNecT.CamNecT_Server.domain.portfolio.dto.response.PortfolioAssetView;
 import CamNecT.CamNecT_Server.domain.portfolio.dto.response.PortfolioDetailResponse;
 import CamNecT.CamNecT_Server.domain.portfolio.dto.response.PortfolioPreviewResponse;
+import CamNecT.CamNecT_Server.domain.portfolio.dto.response.PortfolioResponse;
 import CamNecT.CamNecT_Server.domain.portfolio.model.PortfolioAsset;
 import CamNecT.CamNecT_Server.domain.portfolio.model.PortfolioProject;
 import CamNecT.CamNecT_Server.domain.portfolio.repository.PortfolioAssetRepository;
@@ -39,19 +41,21 @@ public class PortfolioService {
     private final UploadTicketRepository ticketRepo;
     private final FileStorage fileStorage;
 
-    public List<PortfolioPreviewResponse> portfolioPreview(Long userId) {
+    public PortfolioResponse<List<PortfolioPreviewResponse>> portfolioPreview(Long userId, Long portfolioUserId) {
         List<PortfolioPreviewResponse> rows = portfolioRepository.findPreviewsByUserId(userId);
 
-        return rows.stream()
+        List<PortfolioPreviewResponse> resultList =  rows.stream()
                 .map(r -> {
                     String key = r.thumbnailUrl(); // DB에 저장된 건 key
                     String url = presignOrNull(key, null, null);
-                    return new PortfolioPreviewResponse(r.portfolioId(), r.title(), url);
+                    return new PortfolioPreviewResponse(r.portfolioId(), r.title(), url, r.isPublic(), r.isFavorite());
                 })
                 .toList();
+
+        return PortfolioResponse.of(userId.equals(portfolioUserId), resultList);
     }
 
-    public PortfolioDetailResponse portfolioDetail(Long userId, Long portfolioId) {
+    public PortfolioResponse<PortfolioDetailResponse> portfolioDetail(Long userId, Long portfolioUserId, Long portfolioId) {
 
         PortfolioProject portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.PORTFOLIO_NOT_FOUND));
@@ -60,7 +64,7 @@ public class PortfolioService {
 
         String thumbKey = portfolio.getThumbnailUrl();
         String thumbUrl = presignOrNull(thumbKey, "thumbnail", null);
-        portfolio.setThumbnailUrl(thumbUrl);
+        PortfolioProjectDto projectDto = PortfolioProjectDto.from(portfolio, thumbUrl);
 
         List<PortfolioAsset> assets = portfolioAssetRepository.findAssetsByPortfolioId(portfolioId);
 
@@ -75,11 +79,14 @@ public class PortfolioService {
                 ))
                 .collect(Collectors.toList());
 
-        return new PortfolioDetailResponse(isMine, portfolio, views);
+        return PortfolioResponse.of(userId.equals(portfolioUserId), new PortfolioDetailResponse(isMine, projectDto, views));
     }
 
     @Transactional
-    public PortfolioPreviewResponse create(Long userId, PortfolioRequest request) {
+    public PortfolioPreviewResponse create(Long userId, Long portfolioUserId, PortfolioRequest request) {
+
+        if(!userId.equals(portfolioUserId))
+            throw new CustomException(UserErrorCode.PORTFOLIO_FORBIDDEN);
 
         //요청에 따라 PortfolioProject 생성
         PortfolioProject project = PortfolioProject.builder()
@@ -144,7 +151,9 @@ public class PortfolioService {
         return new PortfolioPreviewResponse(
                 saved.getPortfolioId(),
                 saved.getTitle(),
-                presignOrNull(saved.getThumbnailUrl(), "thumbnail", null)
+                presignOrNull(saved.getThumbnailUrl(), "thumbnail", null),
+                saved.isPublic(),
+                saved.isFavorite()
         );
     }
 
@@ -250,8 +259,38 @@ public class PortfolioService {
         return new PortfolioPreviewResponse(
                 project.getPortfolioId(),
                 project.getTitle(),
-                presignOrNull(project.getThumbnailUrl(), "thumbnail", null)
+                presignOrNull(project.getThumbnailUrl(), "thumbnail", null),
+                project.isPublic(),
+                project.isFavorite()
         );
+    }
+
+    @Transactional
+    public boolean togglePublic(Long userId, Long portfolioId) {
+        PortfolioProject project = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.PORTFOLIO_NOT_FOUND)); // 포트폴리오를 찾을 수 없습니다.
+
+        validateOwnership(userId, project);
+
+        project.setPublic(!project.isPublic());
+        return project.isPublic();
+    }
+
+    @Transactional
+    public boolean toggleFavorite(Long userId, Long portfolioId) {
+        PortfolioProject project = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.PORTFOLIO_NOT_FOUND)); // 포트폴리오를 찾을 수 없습니다.
+
+        validateOwnership(userId, project);
+
+        project.setFavorite(!project.isFavorite());
+        return project.isFavorite();
+    }
+
+    private void validateOwnership(Long userId, PortfolioProject project) {
+        if (!project.getUserId().equals(userId)) {
+            throw new CustomException(UserErrorCode.PORTFOLIO_FORBIDDEN); // 수정 권한이 없습니다.
+        }
     }
 
     public void delete(Long userId, Long portfolioId) {


### PR DESCRIPTION
## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- portfolioPreview - 포트폴리오 정렬 반

- PortfolioPreviewResponse - 공개 여부, 즐겨찾기 반환

- PortfolioDetailResponse - asset 중복 반환 dto 수정

- PortfolioService - 엔티티 직접 변경에서 dto에 데이터를 추가하는 방식으로 dirtyChecking 방지

- ApiResponse 적용 - issue

- 요청에서 본인 포트폴리오인지 검사 & 알맞은 응답 반환

- 포트폴리오 수정, 삭제 구현

- 프로젝트 비공개, 즐겨찾기 API 추가

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요


## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호

- close: #67 
- close: #68 
- #53 
