### PR TITLE
Feat/adminannouncement : 어드민 알림 기능 & 엑세스토큰 수정

### DIFF
--- a/src/main/java/CamNecT/server/domain/users/repository/UserRepository.java
+++ b/src/main/java/CamNecT/server/domain/users/repository/UserRepository.java
@@ -1,8 +1,11 @@
 package CamNecT.server.domain.users.repository;
 
 import CamNecT.server.domain.users.model.UserRole;
+import CamNecT.server.domain.users.model.UserStatus;
 import CamNecT.server.domain.users.model.Users;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -27,4 +30,7 @@ public interface UserRepository extends JpaRepository<Users, Long> {
 
     @Query("select u.name from Users u where u.userId = :userId")
     Optional<String> findNameByUserId(@Param("userId") Long userId);
+
+    @Query("select u.userId from Users u where u.status = :status order by u.userId asc")
+    Slice<Long> findUserIdsByStatus(@Param("status") UserStatus status, Pageable pageable);
 }

--- a/src/main/java/CamNecT/server/global/notification/controller/NotificationController.java
+++ b/src/main/java/CamNecT/server/global/notification/controller/NotificationController.java
@@ -2,8 +2,11 @@ package CamNecT.server.global.notification.controller;
 
 import CamNecT.server.global.common.auth.UserId;
 import CamNecT.server.global.common.response.ApiResponse;
+import CamNecT.server.global.notification.dto.request.AdminAnnouncementRequest;
 import CamNecT.server.global.notification.dto.response.NotificationListResponse;
+import CamNecT.server.global.notification.service.AdminAnnouncementService;
 import CamNecT.server.global.notification.service.NotificationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final AdminAnnouncementService adminAnnouncementService;
 
     @GetMapping
     public ApiResponse<NotificationListResponse> list(
@@ -44,6 +48,18 @@ public class NotificationController {
         int updated = notificationService.markAllRead(userId);
         long unread = notificationService.countUnread(userId);
         return ApiResponse.success(new MarkAllReadResponse(updated, unread));
+    }
+
+    @PostMapping("/event")
+    public ApiResponse<AdminAnnouncementResponse> pushEvent(
+            @UserId Long userId,
+            @Valid @RequestBody AdminAnnouncementRequest request
+    ) {
+        long queuedCount = adminAnnouncementService.send(userId, request);
+        return ApiResponse.success(new AdminAnnouncementResponse(queuedCount));
+    }
+
+    public record AdminAnnouncementResponse(long queuedCount) {
     }
 
 

--- a/src/main/java/CamNecT/server/global/notification/controller/NotificationPushController.java
+++ b/src/main/java/CamNecT/server/global/notification/controller/NotificationPushController.java
@@ -2,8 +2,8 @@ package CamNecT.server.global.notification.controller;
 
 import CamNecT.server.global.common.auth.UserId;
 import CamNecT.server.global.common.response.ApiResponse;
-import CamNecT.server.global.notification.dto.RegisterPushTokenRequest;
-import CamNecT.server.global.notification.dto.RegisterPushTokenResponse;
+import CamNecT.server.global.notification.dto.request.RegisterPushTokenRequest;
+import CamNecT.server.global.notification.dto.response.RegisterPushTokenResponse;
 import CamNecT.server.global.notification.service.PushDeviceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/CamNecT/server/global/notification/debug/NotificationDebugController.java
+++ b/src/main/java/CamNecT/server/global/notification/debug/NotificationDebugController.java
@@ -2,7 +2,7 @@ package CamNecT.server.global.notification.debug;
 
 import CamNecT.server.global.common.auth.UserId;
 import CamNecT.server.global.common.response.ApiResponse;
-import CamNecT.server.global.notification.dto.FCMSendRequest;
+import CamNecT.server.global.notification.dto.request.FCMSendRequest;
 import CamNecT.server.global.notification.dto.NotificationPushPayload;
 import CamNecT.server.global.notification.service.NotificationWsPublisher;
 import com.google.firebase.messaging.FirebaseMessaging;

--- a/src/main/java/CamNecT/server/global/notification/dto/request/AdminAnnouncementRequest.java
+++ b/src/main/java/CamNecT/server/global/notification/dto/request/AdminAnnouncementRequest.java
@@ -1,0 +1,26 @@
+package CamNecT.server.global.notification.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record AdminAnnouncementRequest(
+        @NotBlank
+        @Size(max = 255) // 현재 Notification.message가 길이 지정 없으면 DB가 255일 가능성 큼
+        String message,
+
+        @Size(max = 500)
+        String link,
+
+        @NotNull
+        TargetType targetType,
+
+        List<Long> targetUserIds
+) {
+    public enum TargetType {
+        ALL,
+        USERS
+    }
+}

--- a/src/main/java/CamNecT/server/global/notification/dto/request/FCMSendRequest.java
+++ b/src/main/java/CamNecT/server/global/notification/dto/request/FCMSendRequest.java
@@ -1,4 +1,4 @@
-package CamNecT.server.global.notification.dto;
+package CamNecT.server.global.notification.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/CamNecT/server/global/notification/dto/request/RegisterPushTokenRequest.java
+++ b/src/main/java/CamNecT/server/global/notification/dto/request/RegisterPushTokenRequest.java
@@ -1,4 +1,4 @@
-package CamNecT.server.global.notification.dto;
+package CamNecT.server.global.notification.dto.request;
 
 import CamNecT.server.global.notification.model.Platform;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/CamNecT/server/global/notification/dto/response/RegisterPushTokenResponse.java
+++ b/src/main/java/CamNecT/server/global/notification/dto/response/RegisterPushTokenResponse.java
@@ -1,4 +1,4 @@
-package CamNecT.server.global.notification.dto;
+package CamNecT.server.global.notification.dto.response;
 
 public record RegisterPushTokenResponse(
         Long pushDeviceId,

--- a/src/main/java/CamNecT/server/global/notification/event/AdminAnnouncementNotifiableEvent.java
+++ b/src/main/java/CamNecT/server/global/notification/event/AdminAnnouncementNotifiableEvent.java
@@ -1,0 +1,31 @@
+package CamNecT.server.global.notification.event;
+
+import CamNecT.server.global.notification.model.NotificationType;
+
+public record AdminAnnouncementNotifiableEvent(
+        Long receiverUserId,
+        Long actorUserId,
+        String message,
+        String link
+) implements NotifiableEvent {
+
+    @Override
+    public NotificationType type() {
+        return NotificationType.ADMIN_ANNOUNCEMENT;
+    }
+
+    @Override
+    public Long postId() {
+        return null;
+    }
+
+    @Override
+    public Long commentId() {
+        return null;
+    }
+
+    @Override
+    public Long requestId() {
+        return null;
+    }
+}

--- a/src/main/java/CamNecT/server/global/notification/model/NotificationType.java
+++ b/src/main/java/CamNecT/server/global/notification/model/NotificationType.java
@@ -22,4 +22,7 @@ public enum NotificationType {
 
     //COFFEE_CHAT 채팅 메세지 수신
     CHAT_MESSAGE_RECEIVED,
+
+    // 관리자 이벤트/공지
+    ADMIN_ANNOUNCEMENT
 }

--- a/src/main/java/CamNecT/server/global/notification/service/AdminAnnouncementBatchService.java
+++ b/src/main/java/CamNecT/server/global/notification/service/AdminAnnouncementBatchService.java
@@ -1,0 +1,39 @@
+package CamNecT.server.global.notification.service;
+
+import CamNecT.server.global.notification.dto.request.AdminAnnouncementRequest;
+import CamNecT.server.global.notification.event.AdminAnnouncementNotifiableEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAnnouncementBatchService {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public long dispatch(Long adminUserId, AdminAnnouncementRequest request, List<Long> receiverIds) {
+        String link = normalize(request.link());
+
+        for (Long receiverId : receiverIds) {
+            eventPublisher.publishEvent(
+                    new AdminAnnouncementNotifiableEvent(
+                            receiverId,
+                            null, // 시스템 알림으로 보이게
+                            request.message(),
+                            link
+                    )
+            );
+        }
+
+        return receiverIds.size();
+    }
+
+    private String normalize(String link) {
+        return (link == null || link.isBlank()) ? null : link;
+    }
+}

--- a/src/main/java/CamNecT/server/global/notification/service/AdminAnnouncementService.java
+++ b/src/main/java/CamNecT/server/global/notification/service/AdminAnnouncementService.java
@@ -1,0 +1,76 @@
+package CamNecT.server.global.notification.service;
+
+import CamNecT.server.domain.users.model.Users;
+import CamNecT.server.domain.users.repository.UserRepository;
+import CamNecT.server.global.notification.dto.request.AdminAnnouncementRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static CamNecT.server.global.notification.dto.request.AdminAnnouncementRequest.TargetType.USERS;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminAnnouncementService {
+
+    private static final int BATCH_SIZE = 500;
+
+    private final UserRepository userRepository;
+    private final AdminAnnouncementBatchService adminAnnouncementBatchService;
+
+    public long send(Long adminUserId, AdminAnnouncementRequest request) {
+        validate(request);
+
+        if (request.targetType() == USERS) {
+            List<Long> receiverIds = resolveSelectedUsers(request.targetUserIds());
+            return adminAnnouncementBatchService.dispatch(adminUserId, request, receiverIds);
+        }
+
+        long total = 0L;
+        int page = 0;
+
+        while (true) {
+            // TODO: 추후에는 findAll(Pageable) 대신 "활성 사용자만" 조회하는 쿼리로 교체
+            Page<Users> result = userRepository.findAll(PageRequest.of(page++, BATCH_SIZE));
+            if (result.isEmpty()) {
+                break;
+            }
+
+            List<Long> receiverIds = result.getContent().stream()
+                    .map(Users::getUserId)
+                    .toList();
+
+            total += adminAnnouncementBatchService.dispatch(adminUserId, request, receiverIds);
+
+            if (!result.hasNext()) {
+                break;
+            }
+        }
+
+        log.info("[admin-announcement] sent by admin={}, total={}", adminUserId, total);
+        return total;
+    }
+
+    private void validate(AdminAnnouncementRequest request) {
+        if (request.targetType() == USERS &&
+                (request.targetUserIds() == null || request.targetUserIds().isEmpty())) {
+            throw new IllegalArgumentException("targetUserIds is required when targetType=USERS");
+            // 프로젝트 스타일대로 가려면 ErrorCode 하나 추가해서 CustomException으로 바꾸면 됨
+        }
+    }
+
+    private List<Long> resolveSelectedUsers(List<Long> targetUserIds) {
+        Set<Long> uniqueIds = new LinkedHashSet<>(targetUserIds);
+
+        return userRepository.findAllById(uniqueIds).stream()
+                .map(Users::getUserId)
+                .toList();
+    }
+}

--- a/src/main/java/CamNecT/server/global/notification/service/AdminAnnouncementService.java
+++ b/src/main/java/CamNecT/server/global/notification/service/AdminAnnouncementService.java
@@ -6,7 +6,6 @@ import CamNecT.server.domain.users.repository.UserRepository;
 import CamNecT.server.global.notification.dto.request.AdminAnnouncementRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -40,7 +39,6 @@ public class AdminAnnouncementService {
         int page = 0;
 
         while (true) {
-            // TODO: 추후에는 findAll(Pageable) 대신 "활성 사용자만" 조회하는 쿼리로 교체
             Slice<Long> result = userRepository.findUserIdsByStatus(UserStatus.ACTIVE, PageRequest.of(page++, BATCH_SIZE));
             if (result.isEmpty()) break;
 

--- a/src/main/java/CamNecT/server/global/notification/service/AdminAnnouncementService.java
+++ b/src/main/java/CamNecT/server/global/notification/service/AdminAnnouncementService.java
@@ -1,5 +1,6 @@
 package CamNecT.server.global.notification.service;
 
+import CamNecT.server.domain.users.model.UserStatus;
 import CamNecT.server.domain.users.model.Users;
 import CamNecT.server.domain.users.repository.UserRepository;
 import CamNecT.server.global.notification.dto.request.AdminAnnouncementRequest;
@@ -7,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.LinkedHashSet;
@@ -30,6 +32,7 @@ public class AdminAnnouncementService {
 
         if (request.targetType() == USERS) {
             List<Long> receiverIds = resolveSelectedUsers(request.targetUserIds());
+            if (receiverIds.isEmpty()) return 0L;
             return adminAnnouncementBatchService.dispatch(adminUserId, request, receiverIds);
         }
 
@@ -38,20 +41,16 @@ public class AdminAnnouncementService {
 
         while (true) {
             // TODO: 추후에는 findAll(Pageable) 대신 "활성 사용자만" 조회하는 쿼리로 교체
-            Page<Users> result = userRepository.findAll(PageRequest.of(page++, BATCH_SIZE));
-            if (result.isEmpty()) {
-                break;
-            }
+            Slice<Long> result = userRepository.findUserIdsByStatus(UserStatus.ACTIVE, PageRequest.of(page++, BATCH_SIZE));
+            if (result.isEmpty()) break;
 
-            List<Long> receiverIds = result.getContent().stream()
-                    .map(Users::getUserId)
-                    .toList();
+            total += adminAnnouncementBatchService.dispatch(
+                    adminUserId,
+                    request,
+                    result.getContent()
+            );
 
-            total += adminAnnouncementBatchService.dispatch(adminUserId, request, receiverIds);
-
-            if (!result.hasNext()) {
-                break;
-            }
+            if (!result.hasNext()) break;
         }
 
         log.info("[admin-announcement] sent by admin={}, total={}", adminUserId, total);

--- a/src/main/java/CamNecT/server/global/notification/service/PushDeviceService.java
+++ b/src/main/java/CamNecT/server/global/notification/service/PushDeviceService.java
@@ -1,6 +1,6 @@
 package CamNecT.server.global.notification.service;
 
-import CamNecT.server.global.notification.dto.RegisterPushTokenRequest;
+import CamNecT.server.global.notification.dto.request.RegisterPushTokenRequest;
 import CamNecT.server.global.notification.model.PushDevice;
 import CamNecT.server.global.notification.repository.PushDeviceRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/CamNecT/server/global/notification/util/NotificationLinkResolver.java
+++ b/src/main/java/CamNecT/server/global/notification/util/NotificationLinkResolver.java
@@ -33,7 +33,7 @@ public class NotificationLinkResolver {
                         template(p.getChatRoom(), "roomId", requireRoomId(e));
 
                 // 포인트 등: 별도 화면이 없으면 fallback
-                case POINT_EARNED, POINT_SPENT -> fallback();
+                case POINT_EARNED, POINT_SPENT, ADMIN_ANNOUNCEMENT -> fallback();
             };
         } catch (CustomException ex) {
             throw ex; // 원하시면 fallback()로 내려도 됩니다.

--- a/src/main/java/CamNecT/server/global/notification/util/NotificationUtil.java
+++ b/src/main/java/CamNecT/server/global/notification/util/NotificationUtil.java
@@ -22,6 +22,7 @@ public final class NotificationUtil {
             case COFFEE_CHAT_ACCEPTED -> "[커피챗 수락]"; 
             case TEAM_RECRUIT_ACCEPTED -> "[팀 모집 수락]";
             case CHAT_MESSAGE_RECEIVED -> "[새 메시지]";
+            case ADMIN_ANNOUNCEMENT ->  "[이벤트]";
             default -> "[알림]";
         };
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -150,7 +150,7 @@ server:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration-ms: 1209600000 #360000        # 6min
+  access-token-expiration-ms: 172800000 #2day #360000        # 6min
   refresh-token-expiration-ms: 1209600000   # 14day
   verification-token-expiration-ms: 259200000 #3day
 


### PR DESCRIPTION
## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 엑세스토큰 만료기간 14일 -> 2일로 축소
- 어드민 알림(AdminAnnouncement) 관련 클래스들 추가 및 그에따른 기존 클래스 수정
-

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- API "api/notifications/event"로 admin 알림 전송 가능 (세부 사항은 swagger dto 참고)

## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호

- close: #248 
- close: #249 
