### PR TITLE
fix : 비밀번호 수정에서 이메일 인증과 비밀번호 변경 분리

### DIFF
--- a/src/main/java/CamNecT/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/CamNecT/server/domain/auth/controller/AuthController.java
@@ -11,6 +11,8 @@ import CamNecT.server.domain.auth.dto.others.WithdrawRequest;
 import CamNecT.server.domain.auth.dto.password.ResetPasswordRequest;
 import CamNecT.server.domain.auth.dto.password.SendPasswordResetEmailRequest;
 import CamNecT.server.domain.auth.dto.password.SendPasswordResetEmailResponse;
+import CamNecT.server.domain.auth.dto.password.VerifyPasswordResetEmailRequest;
+import CamNecT.server.domain.auth.dto.password.VerifyPasswordResetEmailResponse;
 import CamNecT.server.domain.auth.dto.signup.*;
 import CamNecT.server.domain.auth.dto.signup.SendSignupEmailRequest;
 import CamNecT.server.domain.auth.dto.signup.SendSignupEmailResponse;
@@ -145,11 +147,20 @@ public class AuthController {
         return new SendPasswordResetEmailResponse(req.email(), expiresMinutes);
     }
 
-    @Operation(summary = "비밀번호 재설정", description = "이메일 인증 코드를 검증한 뒤 비밀번호를 변경합니다.")
+    @Operation(summary = "비밀번호 재설정 인증번호 확인", description = "인증 코드를 확인받고 resetToken을 발급합니다.")
+    @PostMapping("/password/reset/email/verify")
+    @ResponseStatus(HttpStatus.OK)
+    public VerifyPasswordResetEmailResponse verifyPasswordResetEmail(
+            @RequestBody @Valid VerifyPasswordResetEmailRequest req
+    ) {
+        return emailVerificationService.verifyPasswordResetEmail(req);
+    }
+
+    @Operation(summary = "비밀번호 재설정", description = "검증된 resetToken으로 비밀번호를 변경합니다.")
     @PatchMapping("/password/reset")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void resetPassword(@RequestBody @Valid ResetPasswordRequest req) {
-        emailVerificationService.verifyPasswordResetAndUpdatePassword(req);
+        emailVerificationService.resetPassword(req);
     }
 
     @Operation(summary = "회원 탈퇴", description = "비밀번호 확인 후 계정을 탈퇴 처리(익명화)합니다.")

--- a/src/main/java/CamNecT/server/domain/auth/dto/password/ResetPasswordRequest.java
+++ b/src/main/java/CamNecT/server/domain/auth/dto/password/ResetPasswordRequest.java
@@ -1,11 +1,8 @@
 package CamNecT.server.domain.auth.dto.password;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 public record ResetPasswordRequest(
-        @Email @NotBlank String email,
-        @NotBlank @Pattern(regexp = "\\d{6}") String code,
+        @NotBlank String resetToken,
         @NotBlank String newPassword
 ) {}

--- a/src/main/java/CamNecT/server/domain/auth/dto/password/VerifyPasswordResetEmailRequest.java
+++ b/src/main/java/CamNecT/server/domain/auth/dto/password/VerifyPasswordResetEmailRequest.java
@@ -1,0 +1,10 @@
+package CamNecT.server.domain.auth.dto.password;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerifyPasswordResetEmailRequest(
+        @Email @NotBlank String email,
+        @NotBlank @Pattern(regexp = "\\d{6}") String code
+) {}

--- a/src/main/java/CamNecT/server/domain/auth/dto/password/VerifyPasswordResetEmailResponse.java
+++ b/src/main/java/CamNecT/server/domain/auth/dto/password/VerifyPasswordResetEmailResponse.java
@@ -1,0 +1,6 @@
+package CamNecT.server.domain.auth.dto.password;
+
+public record VerifyPasswordResetEmailResponse(
+        String resetToken,
+        long expiresMinutes
+) {}

--- a/src/main/java/CamNecT/server/domain/auth/service/PasswordService.java
+++ b/src/main/java/CamNecT/server/domain/auth/service/PasswordService.java
@@ -33,10 +33,14 @@ public class PasswordService {
     }
 
     @Transactional
-    public void resetPasswordByEmail(String email, String newPassword) {
-        Users user = userRepository.findByEmail(email)
+    public void resetPasswordByUserId(Long userId, String newPassword) {
+        Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
+        resetPassword(user, newPassword);
+    }
+
+    private void resetPassword(Users user, String newPassword) {
         validatePassword(newPassword);
         if (passwordEncoder.matches(newPassword, user.getPasswordHash())) {
             throw new CustomException(AuthErrorCode.SAME_AS_CURRENT_PASSWORD);

--- a/src/main/java/CamNecT/server/domain/verification/email/service/EmailVerificationService.java
+++ b/src/main/java/CamNecT/server/domain/verification/email/service/EmailVerificationService.java
@@ -1,6 +1,8 @@
 package CamNecT.server.domain.verification.email.service;
 
 import CamNecT.server.domain.auth.dto.password.ResetPasswordRequest;
+import CamNecT.server.domain.auth.dto.password.VerifyPasswordResetEmailRequest;
+import CamNecT.server.domain.auth.dto.password.VerifyPasswordResetEmailResponse;
 import CamNecT.server.domain.auth.dto.signup.VerifySignupEmailRequest;
 import CamNecT.server.domain.auth.dto.signup.VerifySignupEmailResponse;
 import CamNecT.server.domain.auth.service.PasswordService;
@@ -16,6 +18,7 @@ import CamNecT.server.global.common.exception.CustomException;
 import CamNecT.server.global.common.exception.InvalidPropertiesException;
 import CamNecT.server.global.common.response.errorcode.bydomains.AuthErrorCode;
 import CamNecT.server.global.common.response.errorcode.bydomains.VerificationErrorCode;
+import CamNecT.server.global.jwt.model.TokenType;
 import CamNecT.server.global.jwt.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -107,13 +110,11 @@ public class EmailVerificationService {
     }
 
     @Transactional
-    public void verifyPasswordResetAndUpdatePassword(ResetPasswordRequest req) {
+    public VerifyPasswordResetEmailResponse verifyPasswordResetEmail(VerifyPasswordResetEmailRequest req) {
         Users user = userRepository.findByEmail(req.email())
                 .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
-        if (user.getStatus() == UserStatus.SUSPENDED) {
-            throw new CustomException(AuthErrorCode.USER_SUSPENDED);
-        }
+        validateRecoverableUser(user);
 
         EmailVerificationToken token = tokenRepository.findTopByEmailAndUsedAtIsNullOrderByIdDesc(req.email())
                 .orElseThrow(() -> new CustomException(VerificationErrorCode.NO_ACTIVE_CODE));
@@ -127,9 +128,24 @@ public class EmailVerificationService {
             throw new CustomException(VerificationErrorCode.INVALID_CODE);
         }
 
-        passwordService.resetPasswordByEmail(req.email(), req.newPassword());
         token.markUsed();
         token.linkUser(user);
+
+        String resetToken = jwtUtil.generatePasswordResetToken(user.getUserId(), user.getRole());
+        long expiresMinutes = jwtUtil.getVerificationTokenExpirationMs() / 60000L;
+
+        return new VerifyPasswordResetEmailResponse(resetToken, expiresMinutes);
+    }
+
+    @Transactional
+    public void resetPassword(ResetPasswordRequest req) {
+        jwtUtil.validateOrThrow(req.resetToken());
+        if (jwtUtil.getTokenType(req.resetToken()) != TokenType.PASSWORD_RESET) {
+            throw new CustomException(AuthErrorCode.TOKEN_TYPE_NOT_ALLOWED);
+        }
+
+        Long userId = jwtUtil.getUserId(req.resetToken());
+        passwordService.resetPasswordByUserId(userId, req.newPassword());
     }
 
     @Transactional

--- a/src/main/java/CamNecT/server/global/common/auth/AuthInterceptor.java
+++ b/src/main/java/CamNecT/server/global/common/auth/AuthInterceptor.java
@@ -38,11 +38,12 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         String uri = request.getRequestURI();
 
-        //TODO : REFRESH TOKEN도 사용처 만들기
-        if (type == TokenType.REFRESH) { //현재는 refresh는 안쓰고 있습니다!!
+        if (type == TokenType.ACCESS) {
+            // pass
+        } else if (type == TokenType.VERIFICATION && isAllowedForVerificationToken(uri)) {
+            // pass
+        } else {
             throw new CustomException(AuthErrorCode.TOKEN_TYPE_NOT_ALLOWED);
-        } else if (type == TokenType.VERIFICATION && !isAllowedForVerificationToken(uri)) {
-                throw new CustomException(AuthErrorCode.TOKEN_TYPE_NOT_ALLOWED);
         }
 
         Long userId = jwtUtil.getUserId(token);

--- a/src/main/java/CamNecT/server/global/jwt/model/TokenType.java
+++ b/src/main/java/CamNecT/server/global/jwt/model/TokenType.java
@@ -3,5 +3,6 @@ package CamNecT.server.global.jwt.model;
 public enum TokenType {
     ACCESS,
     REFRESH,
-    VERIFICATION
+    VERIFICATION,
+    PASSWORD_RESET
 }

--- a/src/main/java/CamNecT/server/global/jwt/util/JwtUtil.java
+++ b/src/main/java/CamNecT/server/global/jwt/util/JwtUtil.java
@@ -54,6 +54,10 @@ public class JwtUtil {
         return generateToken(userId, role, TokenType.VERIFICATION, verificationTokenExpirationMs);
     }
 
+    public String generatePasswordResetToken(Long userId, UserRole role) {
+        return generateToken(userId, role, TokenType.PASSWORD_RESET, verificationTokenExpirationMs);
+    }
+
     private String generateToken(Long userId, UserRole role, TokenType type, long expirationMs) {
         if (userId == null) {
             throw new CustomException(ErrorCode.INTERNAL_ERROR, new IllegalArgumentException("userId is null"));


### PR DESCRIPTION
## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

-
-

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요


## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호

- close: #[issue number]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated password reset verification step that returns a temporary reset token and expiration time.
  * Password resets now use a reset token instead of requiring email and code at the final step.

* **Bug Fixes**
  * Improved token handling so only the correct token types are accepted during auth and password reset flows.
  * Password changes now verify the linked user before updating the password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->