### PR TITLE
fix(home): 팀원모집 요청 미리보기 추가

### DIFF
--- a/src/main/java/CamNecT/server/domain/chat/repository/ChatRequestRepository.java
+++ b/src/main/java/CamNecT/server/domain/chat/repository/ChatRequestRepository.java
@@ -39,18 +39,24 @@ public interface ChatRequestRepository extends JpaRepository<ChatRequest, Long> 
             Long recruitmentId
     );
 
-    long countByReceiver_UserIdAndStatus(Long userId, ChatRequest.RequestStatus status);
+    long countByReceiver_UserIdAndTypeAndStatus(
+            Long userId,
+            ChatRequest.RequestType type,
+            ChatRequest.RequestStatus status
+    );
 
     @Query("""
                 select cr
                 from ChatRequest cr
                 join fetch cr.requester r
                 where cr.receiver.userId = :userId
+                  and cr.type = :type
                   and cr.status = :status
                 order by cr.createdAt desc
             """)
-    List<ChatRequest> findLatestReceivedRequests(
+    List<ChatRequest> findLatestReceivedRequestsByType(
             @Param("userId") Long userId,
+            @Param("type") ChatRequest.RequestType type,
             @Param("status") ChatRequest.RequestStatus status,
             Pageable pageable
     );

--- a/src/main/java/CamNecT/server/domain/chat/service/ChatService.java
+++ b/src/main/java/CamNecT/server/domain/chat/service/ChatService.java
@@ -610,19 +610,55 @@ public class ChatService {
     @Transactional(readOnly = true)
     public HomeResponse.CoffeeChatSection getHomeInbox(Long userId, int limit) {
 
-        long pendingCount = chatRequestRepository.countByReceiver_UserIdAndStatus(
-                userId, ChatRequest.RequestStatus.WAITING
+        HomeRequestInbox inbox = getHomeRequestInbox(
+                userId, ChatRequest.RequestType.COFFEE_CHAT, limit
         );
-        if (pendingCount == 0) return HomeResponse.CoffeeChatSection.empty();
+        if (inbox.pendingCount() == 0) return HomeResponse.CoffeeChatSection.empty();
 
-        List<ChatRequest> latest = chatRequestRepository.findLatestReceivedRequests(
-                userId,
-                ChatRequest.RequestStatus.WAITING,
-                PageRequest.of(0, limit)
+        List<HomeResponse.CoffeeChatSection.CoffeeChatPreview> previews = inbox.previews().stream()
+                .map(preview -> new HomeResponse.CoffeeChatSection.CoffeeChatPreview(
+                        preview.requestId(),
+                        preview.senderUserId(),
+                        preview.senderName(),
+                        preview.majorName(),
+                        preview.studentNo()
+                ))
+                .toList();
+
+        return new HomeResponse.CoffeeChatSection(inbox.pendingCount(), previews);
+    }
+
+    @Transactional(readOnly = true)
+    public HomeResponse.RecruitmentSection getHomeRecruitmentInbox(Long userId, int limit) {
+
+        HomeRequestInbox inbox = getHomeRequestInbox(
+                userId, ChatRequest.RequestType.TEAM_RECRUIT, limit
         );
-        if (latest.isEmpty()) {
-            return new HomeResponse.CoffeeChatSection(pendingCount, List.of());
-        }
+        if (inbox.pendingCount() == 0) return HomeResponse.RecruitmentSection.empty();
+
+        List<HomeResponse.RecruitmentSection.RecruitmentPreview> previews = inbox.previews().stream()
+                .map(preview -> new HomeResponse.RecruitmentSection.RecruitmentPreview(
+                        preview.requestId(),
+                        preview.senderUserId(),
+                        preview.senderName(),
+                        preview.majorName(),
+                        preview.studentNo()
+                ))
+                .toList();
+
+        return new HomeResponse.RecruitmentSection(inbox.pendingCount(), previews);
+    }
+
+    private HomeRequestInbox getHomeRequestInbox(Long userId, ChatRequest.RequestType type, int limit) {
+        long pendingCount = chatRequestRepository.countByReceiver_UserIdAndTypeAndStatus(
+                userId, type, ChatRequest.RequestStatus.WAITING
+        );
+        if (pendingCount == 0) return HomeRequestInbox.empty();
+
+        List<ChatRequest> latest = chatRequestRepository.findLatestReceivedRequestsByType(
+                userId, type, ChatRequest.RequestStatus.WAITING, PageRequest.of(0, limit)
+        );
+        if (latest.isEmpty()) return new HomeRequestInbox(pendingCount, List.of());
 
         List<Long> senderIds = latest.stream()
                 .map(cr -> cr.getRequester().getUserId())
@@ -632,7 +668,7 @@ public class ChatService {
                 userProfileRepository.findGlobalsByUserIdIn(senderIds).stream()
                         .collect(Collectors.toMap(ProfileGlobalDto::userId, it -> it));
 
-        List<HomeResponse.CoffeeChatSection.CoffeeChatPreview> previews = latest.stream()
+        List<HomeRequestPreview> previews = latest.stream()
                 .map(cr -> {
                     Users sender = cr.getRequester();
                     ProfileGlobalDto g = globalMap.get(sender.getUserId());
@@ -640,18 +676,32 @@ public class ChatService {
                     String majorName = (g != null ? g.majorName() : null);
                     String studentNo = (g != null && StringUtils.hasText(g.studentNo()) ? g.studentNo() : null);
 
-                    return new HomeResponse.CoffeeChatSection.CoffeeChatPreview(
+                    return new HomeRequestPreview(
                             cr.getId(),
                             sender.getUserId(),
-                            sender.getName(), // 이름은 sender에서 그대로
+                            sender.getName(),
                             majorName,
                             studentNo
                     );
                 })
                 .toList();
 
-        return new HomeResponse.CoffeeChatSection(pendingCount, previews);
+        return new HomeRequestInbox(pendingCount, previews);
     }
+
+    private record HomeRequestInbox(long pendingCount, List<HomeRequestPreview> previews) {
+        private static HomeRequestInbox empty() {
+            return new HomeRequestInbox(0, List.of());
+        }
+    }
+
+    private record HomeRequestPreview(
+            Long requestId,
+            Long senderUserId,
+            String senderName,
+            String majorName,
+            String studentNo
+    ) {}
 
     @Transactional
     public void rejectAllCoffeeChatRequests(Long userId, ChatRequest.RequestType requestType) {

--- a/src/main/java/CamNecT/server/domain/home/controller/HomeController.java
+++ b/src/main/java/CamNecT/server/domain/home/controller/HomeController.java
@@ -23,7 +23,7 @@ public class HomeController {
 
     private final HomeService homeService;
 
-    @Operation(summary = "통합 홈 조회", description = "사용자 정보, 커피챗 요청, 포인트, 동문 추천, 공모전 미리보기를 조회합니다.")
+    @Operation(summary = "통합 홈 조회", description = "사용자 정보, 커피챗·팀원모집 요청, 포인트, 동문 추천, 공모전 미리보기를 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "40100 유효하지 않거나 만료된 JWT / 41103 인증 헤더 누락·형식 오류 / 41104 토큰 타입 누락 / 41106 허용되지 않은 토큰 타입", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "50000 홈 구성 데이터 조회 또는 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))

--- a/src/main/java/CamNecT/server/domain/home/dto/HomeResponse.java
+++ b/src/main/java/CamNecT/server/domain/home/dto/HomeResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record HomeResponse(
         UserSection user,
         CoffeeChatSection coffeeChat,
+        RecruitmentSection recruitment,
         PointSection point,
         AlumniSection alumni,
         ContestSection contests
@@ -30,6 +31,24 @@ public record HomeResponse(
 
         public static CoffeeChatSection empty() {
             return new CoffeeChatSection(0, List.of());
+        }
+    }
+
+    //팀원모집
+    public record RecruitmentSection(
+            long pendingCount,
+            List<RecruitmentPreview> latest2
+    ) {
+        public record RecruitmentPreview(
+                Long requestId,
+                Long senderUserId,
+                String senderName,
+                String majorName,   // nullable
+                String studentNo    // nullable (학번은 이걸로만)
+        ) {}
+
+        public static RecruitmentSection empty() {
+            return new RecruitmentSection(0, List.of());
         }
     }
 

--- a/src/main/java/CamNecT/server/domain/home/service/HomeService.java
+++ b/src/main/java/CamNecT/server/domain/home/service/HomeService.java
@@ -26,6 +26,7 @@ public class HomeService {
     private final ActivityService contestService;
 
     private static final int HOME_COFFEECHAT_PREVIEW_SIZE = 2;
+    private static final int HOME_RECRUITMENT_PREVIEW_SIZE = 2;
     private static final int HOME_ALUMNI_PREVIEW_SIZE = 2;
     private static final int HOME_CONTEST_PREVIEW_SIZE = 4;
 
@@ -35,6 +36,9 @@ public class HomeService {
 
         HomeResponse.CoffeeChatSection coffeeChat =
                 chatService.getHomeInbox(userId, HOME_COFFEECHAT_PREVIEW_SIZE);
+
+        HomeResponse.RecruitmentSection recruitment =
+                chatService.getHomeRecruitmentInbox(userId, HOME_RECRUITMENT_PREVIEW_SIZE);
 
         int balance = pointWalletRepository.findByUserId(userId)
                 .map(PointWallet::getBalance)
@@ -49,6 +53,7 @@ public class HomeService {
         return new HomeResponse(
                 new HomeResponse.UserSection(user.getName()),
                 coffeeChat,
+                recruitment,
                 new HomeResponse.PointSection(balance),
                 alumni,
                 contests

--- a/src/test/java/CamNecT/server/domain/chat/service/ChatHomeInboxTest.java
+++ b/src/test/java/CamNecT/server/domain/chat/service/ChatHomeInboxTest.java
@@ -1,0 +1,142 @@
+package CamNecT.server.domain.chat.service;
+
+import CamNecT.server.domain.activity.repository.recruitment.TeamRecruitmentRepository;
+import CamNecT.server.domain.chat.model.ChatRequest;
+import CamNecT.server.domain.chat.repository.ChatRepository;
+import CamNecT.server.domain.chat.repository.ChatRequestRepository;
+import CamNecT.server.domain.chat.repository.ChatRoomRepository;
+import CamNecT.server.domain.home.dto.HomeResponse;
+import CamNecT.server.domain.profile.components.majors.repository.MajorRepository;
+import CamNecT.server.domain.profile.dto.ProfileGlobalDto;
+import CamNecT.server.domain.users.model.Users;
+import CamNecT.server.domain.users.repository.UserProfileRepository;
+import CamNecT.server.domain.users.repository.UserRepository;
+import CamNecT.server.domain.users.repository.UserTagMapRepository;
+import CamNecT.server.global.point.service.PointService;
+import CamNecT.server.global.storage.service.PublicUrlIssuer;
+import CamNecT.server.global.tag.repository.TagRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChatHomeInboxTest {
+
+    @Mock UserRepository userRepository;
+    @Mock ChatRepository chatRepository;
+    @Mock ChatRoomRepository chatRoomRepository;
+    @Mock ChatRequestRepository chatRequestRepository;
+    @Mock TagRepository tagRepository;
+    @Mock UserProfileRepository userProfileRepository;
+    @Mock UserTagMapRepository userTagMapRepository;
+    @Mock MajorRepository majorRepository;
+    @Mock TeamRecruitmentRepository recruitmentRepository;
+    @Mock PublicUrlIssuer publicUrlIssuer;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock SimpMessagingTemplate messagingTemplate;
+    @Mock ChatPresenceService presenceService;
+    @Mock PointService pointService;
+
+    @InjectMocks ChatService chatService;
+
+    @Test
+    void separatesCoffeeChatAndRecruitmentCountsAndPreservesSenderPreviews() {
+        Long receiverId = 1L;
+        Users coffeeSender = Users.builder().userId(2L).name("커피 발신자").build();
+        Users recruitmentSender = Users.builder().userId(3L).name("모집 지원자").build();
+        ChatRequest coffeeRequest = request(11L, coffeeSender);
+        ChatRequest recruitmentRequest = request(12L, recruitmentSender);
+
+        when(chatRequestRepository.countByReceiver_UserIdAndTypeAndStatus(
+                receiverId, ChatRequest.RequestType.COFFEE_CHAT, ChatRequest.RequestStatus.WAITING
+        )).thenReturn(2L);
+        when(chatRequestRepository.countByReceiver_UserIdAndTypeAndStatus(
+                receiverId, ChatRequest.RequestType.TEAM_RECRUIT, ChatRequest.RequestStatus.WAITING
+        )).thenReturn(3L);
+        when(chatRequestRepository.findLatestReceivedRequestsByType(
+                receiverId,
+                ChatRequest.RequestType.COFFEE_CHAT,
+                ChatRequest.RequestStatus.WAITING,
+                PageRequest.of(0, 2)
+        )).thenReturn(List.of(coffeeRequest));
+        when(chatRequestRepository.findLatestReceivedRequestsByType(
+                receiverId,
+                ChatRequest.RequestType.TEAM_RECRUIT,
+                ChatRequest.RequestStatus.WAITING,
+                PageRequest.of(0, 2)
+        )).thenReturn(List.of(recruitmentRequest));
+        when(userProfileRepository.findGlobalsByUserIdIn(List.of(2L)))
+                .thenReturn(List.of(new ProfileGlobalDto(2L, "커피 발신자", "컴퓨터공학", "20240001", null)));
+        when(userProfileRepository.findGlobalsByUserIdIn(List.of(3L)))
+                .thenReturn(List.of(new ProfileGlobalDto(3L, "모집 지원자", "경영학", "20230002", null)));
+
+        HomeResponse.CoffeeChatSection coffeeChat = chatService.getHomeInbox(receiverId, 2);
+        HomeResponse.RecruitmentSection recruitment = chatService.getHomeRecruitmentInbox(receiverId, 2);
+
+        assertThat(coffeeChat.pendingCount()).isEqualTo(2L);
+        assertThat(coffeeChat.latest2()).singleElement().satisfies(preview -> {
+            assertThat(preview.requestId()).isEqualTo(11L);
+            assertThat(preview.senderUserId()).isEqualTo(2L);
+            assertThat(preview.senderName()).isEqualTo("커피 발신자");
+            assertThat(preview.majorName()).isEqualTo("컴퓨터공학");
+            assertThat(preview.studentNo()).isEqualTo("20240001");
+        });
+        assertThat(recruitment.pendingCount()).isEqualTo(3L);
+        assertThat(recruitment.latest2()).singleElement().satisfies(preview -> {
+            assertThat(preview.requestId()).isEqualTo(12L);
+            assertThat(preview.senderUserId()).isEqualTo(3L);
+            assertThat(preview.senderName()).isEqualTo("모집 지원자");
+            assertThat(preview.majorName()).isEqualTo("경영학");
+            assertThat(preview.studentNo()).isEqualTo("20230002");
+        });
+    }
+
+    @Test
+    void returnsEmptySectionsWithoutLoadingPreviewsWhenNoRequestsAreWaiting() {
+        Long receiverId = 1L;
+        when(chatRequestRepository.countByReceiver_UserIdAndTypeAndStatus(
+                receiverId, ChatRequest.RequestType.COFFEE_CHAT, ChatRequest.RequestStatus.WAITING
+        )).thenReturn(0L);
+        when(chatRequestRepository.countByReceiver_UserIdAndTypeAndStatus(
+                receiverId, ChatRequest.RequestType.TEAM_RECRUIT, ChatRequest.RequestStatus.WAITING
+        )).thenReturn(0L);
+
+        HomeResponse.CoffeeChatSection coffeeChat = chatService.getHomeInbox(receiverId, 2);
+        HomeResponse.RecruitmentSection recruitment = chatService.getHomeRecruitmentInbox(receiverId, 2);
+
+        assertThat(coffeeChat).isEqualTo(HomeResponse.CoffeeChatSection.empty());
+        assertThat(recruitment).isEqualTo(HomeResponse.RecruitmentSection.empty());
+        verify(chatRequestRepository, never()).findLatestReceivedRequestsByType(
+                receiverId,
+                ChatRequest.RequestType.COFFEE_CHAT,
+                ChatRequest.RequestStatus.WAITING,
+                PageRequest.of(0, 2)
+        );
+        verify(chatRequestRepository, never()).findLatestReceivedRequestsByType(
+                receiverId,
+                ChatRequest.RequestType.TEAM_RECRUIT,
+                ChatRequest.RequestStatus.WAITING,
+                PageRequest.of(0, 2)
+        );
+    }
+
+    private ChatRequest request(Long requestId, Users requester) {
+        ChatRequest request = mock(ChatRequest.class);
+        when(request.getId()).thenReturn(requestId);
+        when(request.getRequester()).thenReturn(requester);
+        return request;
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
- Home에 팀원모집 수도 볼 수 있게 수정
- 커피챗요청과 팀원모집을 구분
- 기존 최신 2명 제공 로직은 유지 프론트 처리에 맡김

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요


## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호

- close: #[issue number]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a team recruitment request section to the home screen.
  * Displays pending request counts and the latest recruitment requests, including sender details.
  * Coffee-chat and recruitment inboxes now support separate request categories.

* **Bug Fixes**
  * Empty inboxes no longer trigger unnecessary request lookups.

* **Tests**
  * Added coverage for recruitment and coffee-chat inbox counts, previews, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->