### PR TITLE
Fix/auth home update

### DIFF
--- a/src/main/java/CamNecT/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/CamNecT/server/domain/auth/controller/AuthController.java
@@ -59,6 +59,7 @@ public class AuthController {
             description = "아이디/비밀번호로 로그인하고 현재 가입 단계에 맞는 토큰과 nextStep을 반환합니다. 관리자 승인 후 초기 설정 안내가 남은 ACTIVE 사용자는 access/refresh token과 VERIFICATION_COMPLETE를 받습니다."
     )
     @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(schema = @Schema(implementation = LoginResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "40000 아이디 또는 비밀번호 요청값 검증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "41101 아이디 또는 비밀번호 불일치", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "41302 정지된 사용자 / 41303 탈퇴한 사용자", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -74,6 +75,7 @@ public class AuthController {
 
     @Operation(summary = "아이디 중복확인", description = "사용 가능하면 true, 이미 사용 중이면 false")
     @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "아이디 사용 가능 여부 조회 성공", content = @Content(schema = @Schema(implementation = Boolean.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "50000 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/{username}/available")
@@ -154,6 +156,7 @@ public class AuthController {
             description = "현재 사용자의 서버 저장 refresh token을 삭제합니다. 클라이언트는 보관 중인 access/refresh token도 함께 삭제해야 합니다."
     )
     @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공", content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "41102 Bearer 형식 오류 / 41103 유효하지 않은 토큰 / 41104 토큰 누락 / 41106 Access Token이 아님", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "41302 정지된 사용자 / 41303 탈퇴한 사용자", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "50000 로그아웃 처리 또는 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
@@ -165,6 +168,7 @@ public class AuthController {
 
     @Operation(summary = "인증 완료 화면 정보 조회", description = "초기 설정 안내가 남은 ACTIVE 사용자의 인증 완료 화면에 필요한 이름/학번/학교/학과를 반환합니다.")
     @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 완료 화면 정보 조회 성공", content = @Content(schema = @Schema(implementation = VerificationCompleteResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "41102 Bearer 형식 오류 / 41103 유효하지 않은 토큰 / 41104 토큰 누락 / 41106 Access Token이 아님", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "41302 정지된 사용자 / 41303 탈퇴한 사용자", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "44402 사용자 프로필을 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),

--- a/src/main/java/CamNecT/server/domain/home/dto/HomeResponse.java
+++ b/src/main/java/CamNecT/server/domain/home/dto/HomeResponse.java
@@ -37,7 +37,7 @@ public record HomeResponse(
     //팀원모집
     public record RecruitmentSection(
             long pendingCount,
-            List<RecruitmentPreview> latest2
+            List<RecruitmentPreview> latest5
     ) {
         public record RecruitmentPreview(
                 Long requestId,

--- a/src/main/java/CamNecT/server/domain/home/service/HomeService.java
+++ b/src/main/java/CamNecT/server/domain/home/service/HomeService.java
@@ -26,7 +26,7 @@ public class HomeService {
     private final ActivityService contestService;
 
     private static final int HOME_COFFEECHAT_PREVIEW_SIZE = 2;
-    private static final int HOME_RECRUITMENT_PREVIEW_SIZE = 2;
+    private static final int HOME_RECRUITMENT_PREVIEW_SIZE = 5;
     private static final int HOME_ALUMNI_PREVIEW_SIZE = 2;
     private static final int HOME_CONTEST_PREVIEW_SIZE = 4;
 

--- a/src/test/java/CamNecT/server/domain/chat/service/ChatHomeInboxTest.java
+++ b/src/test/java/CamNecT/server/domain/chat/service/ChatHomeInboxTest.java
@@ -1,28 +1,17 @@
 package CamNecT.server.domain.chat.service;
 
-import CamNecT.server.domain.activity.repository.recruitment.TeamRecruitmentRepository;
 import CamNecT.server.domain.chat.model.ChatRequest;
-import CamNecT.server.domain.chat.repository.ChatRepository;
 import CamNecT.server.domain.chat.repository.ChatRequestRepository;
-import CamNecT.server.domain.chat.repository.ChatRoomRepository;
 import CamNecT.server.domain.home.dto.HomeResponse;
-import CamNecT.server.domain.profile.components.majors.repository.MajorRepository;
 import CamNecT.server.domain.profile.dto.ProfileGlobalDto;
 import CamNecT.server.domain.users.model.Users;
 import CamNecT.server.domain.users.repository.UserProfileRepository;
-import CamNecT.server.domain.users.repository.UserRepository;
-import CamNecT.server.domain.users.repository.UserTagMapRepository;
-import CamNecT.server.global.point.service.PointService;
-import CamNecT.server.global.storage.service.PublicUrlIssuer;
-import CamNecT.server.global.tag.repository.TagRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.util.List;
 
@@ -35,20 +24,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ChatHomeInboxTest {
 
-    @Mock UserRepository userRepository;
-    @Mock ChatRepository chatRepository;
-    @Mock ChatRoomRepository chatRoomRepository;
     @Mock ChatRequestRepository chatRequestRepository;
-    @Mock TagRepository tagRepository;
     @Mock UserProfileRepository userProfileRepository;
-    @Mock UserTagMapRepository userTagMapRepository;
-    @Mock MajorRepository majorRepository;
-    @Mock TeamRecruitmentRepository recruitmentRepository;
-    @Mock PublicUrlIssuer publicUrlIssuer;
-    @Mock ApplicationEventPublisher eventPublisher;
-    @Mock SimpMessagingTemplate messagingTemplate;
-    @Mock ChatPresenceService presenceService;
-    @Mock PointService pointService;
 
     @InjectMocks ChatService chatService;
 
@@ -76,7 +53,7 @@ class ChatHomeInboxTest {
                 receiverId,
                 ChatRequest.RequestType.TEAM_RECRUIT,
                 ChatRequest.RequestStatus.WAITING,
-                PageRequest.of(0, 2)
+                PageRequest.of(0, 5)
         )).thenReturn(List.of(recruitmentRequest));
         when(userProfileRepository.findGlobalsByUserIdIn(List.of(2L)))
                 .thenReturn(List.of(new ProfileGlobalDto(2L, "커피 발신자", "컴퓨터공학", "20240001", null)));
@@ -84,7 +61,7 @@ class ChatHomeInboxTest {
                 .thenReturn(List.of(new ProfileGlobalDto(3L, "모집 지원자", "경영학", "20230002", null)));
 
         HomeResponse.CoffeeChatSection coffeeChat = chatService.getHomeInbox(receiverId, 2);
-        HomeResponse.RecruitmentSection recruitment = chatService.getHomeRecruitmentInbox(receiverId, 2);
+        HomeResponse.RecruitmentSection recruitment = chatService.getHomeRecruitmentInbox(receiverId, 5);
 
         assertThat(coffeeChat.pendingCount()).isEqualTo(2L);
         assertThat(coffeeChat.latest2()).singleElement().satisfies(preview -> {
@@ -95,7 +72,7 @@ class ChatHomeInboxTest {
             assertThat(preview.studentNo()).isEqualTo("20240001");
         });
         assertThat(recruitment.pendingCount()).isEqualTo(3L);
-        assertThat(recruitment.latest2()).singleElement().satisfies(preview -> {
+        assertThat(recruitment.latest5()).singleElement().satisfies(preview -> {
             assertThat(preview.requestId()).isEqualTo(12L);
             assertThat(preview.senderUserId()).isEqualTo(3L);
             assertThat(preview.senderName()).isEqualTo("모집 지원자");
@@ -115,7 +92,7 @@ class ChatHomeInboxTest {
         )).thenReturn(0L);
 
         HomeResponse.CoffeeChatSection coffeeChat = chatService.getHomeInbox(receiverId, 2);
-        HomeResponse.RecruitmentSection recruitment = chatService.getHomeRecruitmentInbox(receiverId, 2);
+        HomeResponse.RecruitmentSection recruitment = chatService.getHomeRecruitmentInbox(receiverId, 5);
 
         assertThat(coffeeChat).isEqualTo(HomeResponse.CoffeeChatSection.empty());
         assertThat(recruitment).isEqualTo(HomeResponse.RecruitmentSection.empty());
@@ -129,7 +106,7 @@ class ChatHomeInboxTest {
                 receiverId,
                 ChatRequest.RequestType.TEAM_RECRUIT,
                 ChatRequest.RequestStatus.WAITING,
-                PageRequest.of(0, 2)
+                PageRequest.of(0, 5)
         );
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
- auth annotation 추가
- home에 동문탐색 2개->5개 넘겨주기로
-

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요


## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호

- close: #[issue number]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The home screen now displays up to five recruitment previews instead of two.
  * Recruitment preview response data now reflects the expanded five-item list.

* **Documentation**
  * Improved API documentation for successful login, username availability, logout, and verification completion responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->