### PR TITLE
fix: improve Redis connection resilience

### DIFF
--- a/src/main/java/CamNecT/server/global/common/config/RedisClientResilienceConfiguration.java
+++ b/src/main/java/CamNecT/server/global/common/config/RedisClientResilienceConfiguration.java
@@ -1,0 +1,47 @@
+package CamNecT.server.global.common.config;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import org.springframework.boot.autoconfigure.data.redis.LettuceClientOptionsBuilderCustomizer;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(RedisClientResilienceProperties.class)
+public class RedisClientResilienceConfiguration {
+
+    @Bean
+    LettuceClientOptionsBuilderCustomizer redisClientOptionsBuilderCustomizer(
+            RedisProperties redisProperties,
+            RedisClientResilienceProperties resilienceProperties
+    ) {
+        Duration connectTimeout = redisProperties.getConnectTimeout() == null
+                ? Duration.ofSeconds(1)
+                : redisProperties.getConnectTimeout();
+
+        SocketOptions.KeepAliveOptions keepAliveOptions = SocketOptions.KeepAliveOptions.builder()
+                .enable(resilienceProperties.isKeepAliveEnabled())
+                .idle(resilienceProperties.getKeepAliveIdle())
+                .interval(resilienceProperties.getKeepAliveInterval())
+                .count(resilienceProperties.getKeepAliveCount())
+                .build();
+
+        SocketOptions socketOptions = SocketOptions.builder()
+                .connectTimeout(connectTimeout)
+                .keepAlive(keepAliveOptions)
+                .tcpNoDelay(true)
+                .build();
+
+        return builder -> builder
+                .autoReconnect(resilienceProperties.isAutoReconnect())
+                .pingBeforeActivateConnection(true)
+                .disconnectedBehavior(resilienceProperties.isRejectCommandsWhileDisconnected()
+                        ? ClientOptions.DisconnectedBehavior.REJECT_COMMANDS
+                        : ClientOptions.DisconnectedBehavior.ACCEPT_COMMANDS)
+                .socketOptions(socketOptions);
+    }
+}

--- a/src/main/java/CamNecT/server/global/common/config/RedisClientResilienceProperties.java
+++ b/src/main/java/CamNecT/server/global/common/config/RedisClientResilienceProperties.java
@@ -1,0 +1,20 @@
+package CamNecT.server.global.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.redis.client")
+public class RedisClientResilienceProperties {
+
+    private boolean autoReconnect = true;
+    private boolean rejectCommandsWhileDisconnected = true;
+    private boolean keepAliveEnabled = true;
+    private Duration keepAliveIdle = Duration.ofSeconds(30);
+    private Duration keepAliveInterval = Duration.ofSeconds(10);
+    private int keepAliveCount = 3;
+}

--- a/src/main/java/CamNecT/server/global/common/response/errorcode/ErrorCode.java
+++ b/src/main/java/CamNecT/server/global/common/response/errorcode/ErrorCode.java
@@ -7,6 +7,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode implements BaseErrorCode {
+    // 503xx
+    REDIS_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, 50310,
+            "일시적으로 서비스를 사용할 수 없습니다. 잠시 후 다시 시도해주세요."),
+
     // 500xx
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "서버 내부 오류가 발생했습니다."),
 

--- a/src/main/java/CamNecT/server/global/common/util/GlobalExceptionHandler.java
+++ b/src/main/java/CamNecT/server/global/common/util/GlobalExceptionHandler.java
@@ -159,6 +159,20 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleUnexpected(Exception e, HttpServletRequest req) {
+        if (RedisFailureDetector.isRedisFailure(e)) {
+            log.error("[RedisUnavailable] {} {} | code={}",
+                    req.getMethod(),
+                    req.getRequestURI(),
+                    ErrorCode.REDIS_UNAVAILABLE.getCode(),
+                    e);
+            return ResponseEntity.status(ErrorCode.REDIS_UNAVAILABLE.getHttpStatus())
+                    .header("Retry-After", "3")
+                    .body(new ErrorResponse(
+                            ErrorCode.REDIS_UNAVAILABLE.getHttpStatus().value(),
+                            ErrorCode.REDIS_UNAVAILABLE.getCode(),
+                            ErrorCode.REDIS_UNAVAILABLE.getMessage()
+                    ));
+        }
         log.error("[UnexpectedException] {} {}", req.getMethod(), req.getRequestURI(), e);
         return response(ErrorCode.INTERNAL_ERROR);
     }

--- a/src/main/java/CamNecT/server/global/common/util/RedisFailureDetector.java
+++ b/src/main/java/CamNecT/server/global/common/util/RedisFailureDetector.java
@@ -1,0 +1,27 @@
+package CamNecT.server.global.common.util;
+
+import io.lettuce.core.RedisException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
+
+public final class RedisFailureDetector {
+
+    private static final int MAX_CAUSE_DEPTH = 20;
+
+    private RedisFailureDetector() {
+    }
+
+    public static boolean isRedisFailure(Throwable throwable) {
+        Throwable current = throwable;
+        int depth = 0;
+        while (current != null && depth++ < MAX_CAUSE_DEPTH) {
+            if (current instanceof RedisException
+                    || current instanceof RedisConnectionFailureException
+                    || current instanceof RedisSystemException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/src/main/java/CamNecT/server/global/websocket/ChatSocketErrorMapper.java
+++ b/src/main/java/CamNecT/server/global/websocket/ChatSocketErrorMapper.java
@@ -7,6 +7,7 @@ import CamNecT.server.global.common.exception.CustomException;
 import CamNecT.server.global.common.response.errorcode.BaseErrorCode;
 import CamNecT.server.global.common.response.errorcode.ErrorCode;
 import CamNecT.server.global.common.response.errorcode.bydomains.CoffeeChatErrorCode;
+import CamNecT.server.global.common.util.RedisFailureDetector;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +59,9 @@ public class ChatSocketErrorMapper {
     }
 
     private BaseErrorCode resolveErrorCode(Throwable throwable) {
+        if (RedisFailureDetector.isRedisFailure(throwable)) {
+            return ErrorCode.REDIS_UNAVAILABLE;
+        }
         Throwable current = throwable;
         int depth = 0;
         while (current != null && depth++ < MAX_CAUSE_DEPTH) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,14 @@ app:
       expiration-minutes: 30
       mail:
         subject: "CamNecT 이메일 인증번호"
+  redis:
+    client:
+      auto-reconnect: ${REDIS_AUTO_RECONNECT:true}
+      reject-commands-while-disconnected: ${REDIS_REJECT_COMMANDS_WHILE_DISCONNECTED:true}
+      keep-alive-enabled: ${REDIS_KEEP_ALIVE_ENABLED:true}
+      keep-alive-idle: ${REDIS_KEEP_ALIVE_IDLE:30s}
+      keep-alive-interval: ${REDIS_KEEP_ALIVE_INTERVAL:10s}
+      keep-alive-count: ${REDIS_KEEP_ALIVE_COUNT:3}
   profile:
     image:
       max-file-size-mb: 20
@@ -123,7 +131,7 @@ spring:
       port: ${REDIS_PORT:6379}
       username: ${REDIS_USERNAME:}
       password: ${REDIS_PASSWORD:}
-      connect-timeout: ${REDIS_CONNECT_TIMEOUT:2s}
+      connect-timeout: ${REDIS_CONNECT_TIMEOUT:1s}
       timeout: ${REDIS_TIMEOUT:2s}
       ssl:
         enabled: ${REDIS_SSL_ENABLED:false}

--- a/src/test/java/CamNecT/server/global/common/config/RedisClientResilienceConfigurationTest.java
+++ b/src/test/java/CamNecT/server/global/common/config/RedisClientResilienceConfigurationTest.java
@@ -1,0 +1,36 @@
+package CamNecT.server.global.common.config;
+
+import io.lettuce.core.ClientOptions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedisClientResilienceConfigurationTest {
+
+    @Test
+    void configuresKeepAliveAutoReconnectAndFailFastWhileDisconnected() {
+        RedisProperties redisProperties = new RedisProperties();
+        redisProperties.setConnectTimeout(Duration.ofSeconds(1));
+        RedisClientResilienceProperties resilienceProperties = new RedisClientResilienceProperties();
+
+        var customizer = new RedisClientResilienceConfiguration()
+                .redisClientOptionsBuilderCustomizer(redisProperties, resilienceProperties);
+        ClientOptions.Builder builder = ClientOptions.builder();
+
+        customizer.customize(builder);
+        ClientOptions options = builder.build();
+
+        assertThat(options.isAutoReconnect()).isTrue();
+        assertThat(options.isPingBeforeActivateConnection()).isTrue();
+        assertThat(options.getDisconnectedBehavior())
+                .isEqualTo(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS);
+        assertThat(options.getSocketOptions().getConnectTimeout()).isEqualTo(Duration.ofSeconds(1));
+        assertThat(options.getSocketOptions().getKeepAlive().isEnabled()).isTrue();
+        assertThat(options.getSocketOptions().getKeepAlive().getIdle()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(options.getSocketOptions().getKeepAlive().getInterval()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(options.getSocketOptions().getKeepAlive().getCount()).isEqualTo(3);
+    }
+}

--- a/src/test/java/CamNecT/server/global/common/util/GlobalExceptionHandlerTest.java
+++ b/src/test/java/CamNecT/server/global/common/util/GlobalExceptionHandlerTest.java
@@ -1,8 +1,12 @@
 package CamNecT.server.global.common.util;
 
+import CamNecT.server.global.common.response.ErrorResponse;
 import CamNecT.server.global.common.response.ValidationErrorResponse;
+import io.lettuce.core.RedisCommandTimeoutException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
@@ -33,5 +37,24 @@ class GlobalExceptionHandlerTest {
         assertThat(body.errors()).containsExactly(
                 new ValidationErrorResponse.FieldViolation("title", "제목은 필수입니다.")
         );
+    }
+
+    @Test
+    void redisTimeoutReturnsServiceUnavailableWithoutExposingInfrastructureDetails() {
+        QueryTimeoutException exception = new QueryTimeoutException(
+                "Redis command timed out",
+                new RedisCommandTimeoutException("Command timed out")
+        );
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getRequestURI()).thenReturn("/api/auth/login");
+
+        ResponseEntity<ErrorResponse> response = handler.handleUnexpected(exception, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(503);
+        assertThat(response.getHeaders().getFirst("Retry-After")).isEqualTo("3");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo(50310);
+        assertThat(response.getBody().message()).doesNotContainIgnoringCase("redis");
     }
 }

--- a/src/test/java/CamNecT/server/global/websocket/ChatSocketErrorMapperTest.java
+++ b/src/test/java/CamNecT/server/global/websocket/ChatSocketErrorMapperTest.java
@@ -6,6 +6,7 @@ import CamNecT.server.global.common.exception.CustomException;
 import CamNecT.server.global.common.response.errorcode.ErrorCode;
 import CamNecT.server.global.common.response.errorcode.bydomains.CoffeeChatErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lettuce.core.RedisCommandTimeoutException;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.MessageConversionException;
@@ -63,6 +64,18 @@ class ChatSocketErrorMapperTest {
         assertThat(response.status()).isEqualTo(500);
         assertThat(response.code()).isEqualTo(ErrorCode.INTERNAL_ERROR.getCode());
         assertThat(response.message()).doesNotContain("password");
+    }
+
+    @Test
+    void mapsRedisFailureToServiceUnavailable() {
+        ChatSocketErrorResponse response = mapper.map(
+                new RedisCommandTimeoutException("Command timed out"),
+                sendMessage(new byte[0])
+        );
+
+        assertThat(response.status()).isEqualTo(503);
+        assertThat(response.code()).isEqualTo(ErrorCode.REDIS_UNAVAILABLE.getCode());
+        assertThat(response.message()).doesNotContainIgnoringCase("redis");
     }
 
     private Message<?> sendMessage(Object payload) {


### PR DESCRIPTION
## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

-
-

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요


## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호

- close: #[issue number]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Redis connection resilience with automatic reconnect, keep-alive, connection pinging, and configurable timeout settings.
  * Added clearer service-unavailable handling when Redis is temporarily inaccessible.
  * WebSocket and HTTP responses now return HTTP 503 with a retry hint without exposing internal Redis details.

* **Tests**
  * Added coverage for Redis resilience settings and unavailable-service error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->